### PR TITLE
An e2e bot testing skeleton added

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -23,11 +23,13 @@ async def command_start_handler(message: Message) -> None:
 
 @dp.message(Command("help"))
 async def command_help_handler(message: Message) -> None:
+    logging.info(message.text)
     await message.answer("Тут будет инструкция по использованию бота")
 
 
 @dp.message()
 async def echo_handler(message: types.Message) -> None:
+    logging.info(message.text)
     try:
         await message.send_copy(chat_id=message.chat.id)
     except TypeError:

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -1,0 +1,32 @@
+import logging
+import os
+import warnings
+
+import pytest_asyncio
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+from dotenv import load_dotenv
+from pyrogram import Client
+
+logger = logging.getLogger(__name__)
+
+load_dotenv()
+
+api_id = int(os.getenv("APP_ID"))
+api_hash = os.getenv("APP_HASH")
+
+
+@pytest_asyncio.fixture
+async def client():
+    async with Client(
+        "my_account",
+        api_id=api_id,
+        api_hash=api_hash,
+        test_mode=True,
+        in_memory=True,
+        phone_number="99966" + "1" + "2023",
+        phone_code="1" * 5,
+    ) as client:
+        yield client
+        await client.stop()

--- a/bot/tests/e2e/session_telethone.py
+++ b/bot/tests/e2e/session_telethone.py
@@ -1,0 +1,16 @@
+import os
+
+from dotenv import load_dotenv
+from telethon import TelegramClient
+from telethon.sessions import StringSession
+
+load_dotenv()
+
+TOKEN = os.getenv("BOT_TOKEN")
+
+api_id = os.getenv("APP_ID")
+api_hash = os.getenv("APP_HASH")
+
+
+with TelegramClient(StringSession(), api_id, api_hash) as client:
+    print("Session string:", client.session.save())

--- a/bot/tests/test_bot.py
+++ b/bot/tests/test_bot.py
@@ -1,0 +1,20 @@
+import pytest
+from pyrogram import Client
+
+
+@pytest.mark.asyncio
+async def test_echo(client: Client):
+    await client.send_message("NewHeartBot", "Pew Pew")
+    chat = await client.get_chat("@NewHeartBot")
+    hist = client.get_chat_history(chat.id, 1)
+    async for message in hist:
+        assert message.text == "Pew Pew"
+
+
+@pytest.mark.asyncio
+async def test_help(client: Client):
+    await client.send_message("NewHeartBot", "/help")
+    chat = await client.get_chat("@NewHeartBot")
+    hist = client.get_chat_history(chat.id, 1)
+    async for message in hist:
+        assert message.text == "Тут будет инструкция по использованию бота"

--- a/requirements.txt
+++ b/requirements.txt
@@ -114,6 +114,15 @@ pluggy==1.3.0
     # via
     #   -r requirements.in
     #   pytest
+pyaes==1.6.1
+    # via
+    #   -r requirements.in
+    #   pyrogram
+    #   telethon
+pyasn1==0.5.1
+    # via
+    #   -r requirements.in
+    #   rsa
 pydantic==2.5.2
     # via
     #   -r requirements.in
@@ -126,10 +135,24 @@ pyproject-hooks==1.0.0
     # via
     #   -r requirements.in
     #   build
+pyrogram==2.0.106
+    # via -r requirements.in
+pysocks==1.7.1
+    # via
+    #   -r requirements.in
+    #   pyrogram
 pytest==7.4.3
+    # via
+    #   -r requirements.in
+    #   pytest-asyncio
+pytest-asyncio==0.23.2
     # via -r requirements.in
 python-dotenv==1.0.0
     # via -r requirements.in
+rsa==4.9
+    # via
+    #   -r requirements.in
+    #   telethon
 sniffio==1.3.0
     # via
     #   -r requirements.in
@@ -139,6 +162,8 @@ sqlparse==0.4.4
     # via
     #   -r requirements.in
     #   django
+telethon==1.33.1
+    # via -r requirements.in
 typing-extensions==4.9.0
     # via
     #   -r requirements.in

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,6 @@ exclude =
 per-file-ignores =
     */settings.py:E501
 max-complexity = 10
+
+[tool:pytest]   
+asyncio_mode = auto


### PR DESCRIPTION
Я попытался найти наиболее удобный алгоритм e2e тестирования бота (в максимально приближенных к реальности сценариях с использованием ответов от Telegram API, а не их имитаций). 

Пока единственный относительно рабочий алгоритм для меня выглядит как смесь  pytest, pytest_asyncio и Pyrogram (последний является оберткой над MTProto API - протокола передачи данных Telegram, что позволяет направлять сообщения боту и обрабатывать ответы используя соответствующий клиент).

Для тестирования бота необходимо:
1. Создать приложение в API Development tools (https://my.telegram.org/);
2. Сохранить в переменные окружения api_id и api_hash (будут видны после создания приложения);
3. Создать себе аккаунт в тестовой среде в приложении Telegram (https://core.telegram.org/bots/features#testing-your-bot);
4. Создать в тестовой среде нового бота и сохранить его данные в переменную окружения);
5. Для доступа к тестовому боту необходимо, чтобы запросы отправлялись в следующем формате: [https://api.telegram.org/bot<token>/test/METHOD_NAME](https://api.telegram.org/bot%3Ctoken%3E/test/METHOD_NAME). Для этого достаточно добавить к токену бота строчку ‘/test’;
6. В файле conftest.py предусмотрена фикстура, которая осуществляет создание клиента в тестовой среде. Для этого используются специальные выделенные телефонные номера и коды ([auth](https://core.telegram.org/api/auth#test-accounts)), ввиду чего номера надо периодически менять (можно автоматизировать этот процесс);
7. Для запуска тестов необходимо, чтобы тестовый бот был запущен (можно постараться автоматизировать процесс запуска бота перед тестом);
8. Общение будет происходить в чате тестового клиента, а также бота (пользователь напрямую не может получить доступ к этому чату), но есть возможность получить историю сообщения оттуда, в том числе, для целей тестирования (реализовано в тестах);

Вся эта конструкция не всегда работает стабильно, ввиду чего тесты могут падать даже при положительном результате (такое случается в e2e тестировании). На настоящий момент тест echo функции отрабатывает нормально, тест хендлера иногда показывает ошибочное сообщение от бота (‘/help’ вместо заданной в хендлере бота строки). Нужно будет дополнительно поработать над этим.

<img width="654" alt="Screenshot 2023-12-15 at 11 15 40" src="https://github.com/Studio-Yandex-Practicum/predannoeserdce_bot_lesha/assets/114028017/ef406e49-bb59-4dab-bc62-7140187e6d26">

Я пытался реализовать похожий функционал через Telethon, но он пока не желает работать. Код для получения сессии Telethon и саму зависимость я пока оставил в репозитория.